### PR TITLE
🚨 fix SonarQube warnings: Class name convention

### DIFF
--- a/cypress/e2e/step_definitions/checkoutProcess.js
+++ b/cypress/e2e/step_definitions/checkoutProcess.js
@@ -1,35 +1,35 @@
 import { Then } from 'cypress-cucumber-preprocessor/steps';
-import cartPage from '../../pages/cartPage';
-import checkoutConfirmPage from '../../pages/checkoutConfirmPage';
-import finishCheckoutPage from '../../pages/finishCheckoutPage';
+import CartPage from '../../pages/CartPage';
+import CheckoutConfirmPage from '../../pages/CheckoutConfirmPage';
+import FinishCheckoutPage from '../../pages/FinishCheckoutPage';
 
-const CartPage = new cartPage();
-const CheckoutConfirmPage = new checkoutConfirmPage();
-const FinishCheckoutPage = new finishCheckoutPage();
+const cartPage = new CartPage();
+const checkoutConfirmPage = new CheckoutConfirmPage();
+const finishCheckoutPage = new FinishCheckoutPage();
 
 Then('I should see the title of {string}', (title) => {
-    CartPage.validateCartUrl();
-    CartPage.validateCartTitle(title);
+    cartPage.validateCartUrl();
+    cartPage.validateCartTitle(title);
 });
 
 Then('I should see the cart with {string} badget', (numberofProducts) => {
-    CartPage.validateCartBadget(numberofProducts);
+    cartPage.validateCartBadget(numberofProducts);
 });
 
 Then('I should remove the product as desired', () => {
-    CartPage.removeProductFromCart();
+    cartPage.removeProductFromCart();
 });
 
 Then('I should fill all personal of {string} for checkout', (user) => {
-    CartPage.validateCheckoutButton();
+    cartPage.validateCheckoutButton();
     cy.personalInformation(user);
 });
 
 Then('I Check the cost of the product', () => {
-    CheckoutConfirmPage.validateProductPrice();
+    checkoutConfirmPage.validateProductPrice();
 });
 
 Then('I end the process with a success message', () => {
-    CheckoutConfirmPage.clickFinishButton();
-    FinishCheckoutPage.validateFinishMessage();
+    checkoutConfirmPage.clickFinishButton();
+    finishCheckoutPage.validateFinishMessage();
 });

--- a/cypress/e2e/step_definitions/productDetails.js
+++ b/cypress/e2e/step_definitions/productDetails.js
@@ -1,36 +1,36 @@
 import { Then, When } from 'cypress-cucumber-preprocessor/steps';
-import homePage from '../../pages/homePage';
+import HomePage from '../../pages/HomePage';
 
-const HomePage = new homePage();
+const homePage = new HomePage();
 
 Then('I should see the all products', () => {
-    HomePage.validateProductsLenght();
+    homePage.validateProductsLenght();
 });
 
 Then('I should see the title of the products', () => {
-    HomePage.validateTitleofProducts();
+    homePage.validateTitleofProducts();
 });
 
 Then('I should see the price of the products', () => {
-    HomePage.validatePriceofProducts();
+    homePage.validatePriceofProducts();
 });
 
 Then('I should see the description of the products', () => {
-    HomePage.validateDescriptionofProducts();
+    homePage.validateDescriptionofProducts();
 });
 
 Then('I should see the photo of the products', () => {
-    HomePage.validatePhotoofProducts();
+    homePage.validatePhotoofProducts();
 });
 
 When('I order the products by name descendant', () => {
-    HomePage.OrderByNameDescendant();
+    homePage.OrderByNameDescendant();
 });
 
 When('I order the products by price descendant', () => {
-    HomePage.OrderByPriceDescendant();
+    homePage.OrderByPriceDescendant();
 });
 
 When('I add a product to the cart', () => {
-    HomePage.addProductToCartList();
+    homePage.addProductToCartList();
 });

--- a/cypress/e2e/step_definitions/validateUsers.js
+++ b/cypress/e2e/step_definitions/validateUsers.js
@@ -1,13 +1,13 @@
 import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
-import loginPage from '../../pages/loginPage';
-import homePage from '../../pages/homePage';
+import LoginPage from '../../pages/LoginPage';
+import HomePage from '../../pages/HomePage';
 
-const LoginPage = new loginPage();
-const HomePage = new homePage();
+const loginPage = new LoginPage();
+const homePage = new HomePage();
 
 Given('I open the website', () => {
     cy.visit('/');
-    LoginPage.validateLoginPage();
+    loginPage.validateLoginPage();
 });
 
 When('I login with the user {string}', (userName) => {
@@ -15,10 +15,10 @@ When('I login with the user {string}', (userName) => {
 });
 
 Then('I should see the header {string}', (title) => {
-    HomePage.validateInventaryUrl();
-    HomePage.validateHeaderTitle(title);
+    homePage.validateInventaryUrl();
+    homePage.validateHeaderTitle(title);
 });
 
 Then('I should see the warning', () => {
-    LoginPage.warningMessage();
+    loginPage.warningMessage();
 });

--- a/cypress/pages/CartPage.js
+++ b/cypress/pages/CartPage.js
@@ -1,4 +1,4 @@
-class cartPage {
+class CartPage {
     elements = {
         urlPath: () => cy.url(),
         cartTitle: () => cy.get('[data-test="title"]'),
@@ -40,4 +40,4 @@ class cartPage {
     }
 }
 
-export default cartPage;
+export default CartPage;

--- a/cypress/pages/CheckoutConfirmPage.js
+++ b/cypress/pages/CheckoutConfirmPage.js
@@ -1,4 +1,4 @@
-class checkoutConfirmationPage {
+class CheckoutConfirmationPage {
     elements = {
         productPrice: () => cy.get('[data-test="inventory-item-price"]'),
         subtotalLabel: () => cy.get('[data-test="subtotal-label"]'),
@@ -21,4 +21,4 @@ class checkoutConfirmationPage {
     }
 }
 
-export default checkoutConfirmationPage;
+export default CheckoutConfirmationPage;

--- a/cypress/pages/CheckoutInformationPage.js
+++ b/cypress/pages/CheckoutInformationPage.js
@@ -1,6 +1,6 @@
 import { returnObjectSearchingByKey } from '../support/utils/fixtureInteraction';
 
-class checkoutInformationPage {
+class CheckoutInformationPage {
     elements = {
         firstNameField: () => cy.get('[data-test="firstName"]'),
         lastNameField: () => cy.get('[data-test="lastName"]'),
@@ -29,4 +29,4 @@ class checkoutInformationPage {
     }
 }
 
-export default checkoutInformationPage;
+export default CheckoutInformationPage;

--- a/cypress/pages/FinishCheckoutPage.js
+++ b/cypress/pages/FinishCheckoutPage.js
@@ -1,4 +1,4 @@
-class finishCheckoutPage {
+class FinishCheckoutPage {
     elements = {
         thankMessage: () => cy.get('[data-test="complete-header"]'),
         checkoutStatusLabel: () => cy.get('[data-test="title"]'),
@@ -16,4 +16,4 @@ class finishCheckoutPage {
     }
 }
 
-export default finishCheckoutPage;
+export default FinishCheckoutPage;

--- a/cypress/pages/HomePage.js
+++ b/cypress/pages/HomePage.js
@@ -1,4 +1,4 @@
-class homePage {
+class HomePage {
     elements = {
         burguerButton: () => cy.get('#react-burger-menu-btn'),
         allItemsBurgerOption: () => cy.get('#inventory_sidebar_link'),
@@ -74,4 +74,5 @@ class homePage {
         this.elements.cartListButton().click();
     }
 }
-export default homePage;
+
+export default HomePage;

--- a/cypress/pages/LoginPage.js
+++ b/cypress/pages/LoginPage.js
@@ -1,6 +1,6 @@
 import { returnObjectSearchingByKey } from '../support/utils/fixtureInteraction';
 
-class loginPage {
+class LoginPage {
     elements = {
         userField: () => cy.get('[data-test="username"]'),
         passwordField: () => cy.get('[data-test="password"]'),
@@ -37,4 +37,4 @@ class loginPage {
     }
 }
 
-export default loginPage;
+export default LoginPage;

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,17 +1,17 @@
-import loginPage from '../pages/loginPage';
-import checkoutInformationPage from '../pages/checkoutInformationPage';
+import LoginPage from '../pages/LoginPage';
+import CheckoutInformationPage from '../pages/CheckoutInformationPage';
 
-const LoginPage = new loginPage();
-const CheckoutInformationPage = new checkoutInformationPage();
+const loginPage = new LoginPage();
+const checkoutInformationPage = new CheckoutInformationPage();
 
 Cypress.Commands.add('authentication', (userName) => {
     cy.fixture('users').then((userData) => {
-        LoginPage.login(userData, userName);
+        loginPage.login(userData, userName);
     });
 });
 
 Cypress.Commands.add('personalInformation', (userName) => {
     cy.fixture('users').then((userData) => {
-        CheckoutInformationPage.completePersonalInformation(userData, userName);
+        checkoutInformationPage.completePersonalInformation(userData, userName);
     });
 });


### PR DESCRIPTION
Fix SonarQube warnings: Class names should comply with a naming convention. [See explanation](https://rules.sonarsource.com/javascript/RSPEC-101/?search=Class%20names%20should).

**Evidence**

SonarQube
![image](https://github.com/user-attachments/assets/b942b2c9-ce31-4945-9b16-e3287513a518)

Test passing
![image](https://github.com/user-attachments/assets/40b5977c-eea3-47d3-9a71-c6e7bdb8bff6)
