### PR TITLE
🚨 fix linter warnings

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,4 +1,5 @@
 const { defineConfig } = require('cypress');
+const setupNodeEvents = require('./cypress/plugins/index');
 
 module.exports = defineConfig({
     numTestsKeptInMemory: 0,
@@ -13,7 +14,7 @@ module.exports = defineConfig({
     e2e: {
         baseUrl: 'https://www.saucedemo.com',
         setupNodeEvents(on, config) {
-            return require('./cypress/plugins/index.js')(on, config);
+            return setupNodeEvents(on, config);
         },
         specPattern: 'cypress/e2e/**/*.feature',
         defaultCommandTimeout: 10000,

--- a/cypress/pages/CheckoutInformationPage.js
+++ b/cypress/pages/CheckoutInformationPage.js
@@ -1,4 +1,4 @@
-import { returnObjectSearchingByKey } from '../support/utils/fixtureInteraction';
+import returnObjectSearchingByKey from '../support/utils/fixtureInteraction';
 
 class CheckoutInformationPage {
     elements = {

--- a/cypress/pages/LoginPage.js
+++ b/cypress/pages/LoginPage.js
@@ -1,4 +1,4 @@
-import { returnObjectSearchingByKey } from '../support/utils/fixtureInteraction';
+import returnObjectSearchingByKey from '../support/utils/fixtureInteraction';
 
 class LoginPage {
     elements = {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,5 +1,5 @@
 const cucumber = require('cypress-cucumber-preprocessor').default;
 
-module.exports = (on, config) => {
+module.exports = (on) => {
     on('file:preprocessor', cucumber());
 };

--- a/cypress/support/utils/fixtureInteraction.js
+++ b/cypress/support/utils/fixtureInteraction.js
@@ -4,7 +4,9 @@
  * @param {String} key
  * @returns the object searched by key entry
  */
-export const returnObjectSearchingByKey = (arrayObject, key) => {
+const returnObjectSearchingByKey = (arrayObject, key) => {
     const userObject = arrayObject.filter((item) => item.username === key);
     return userObject[0];
 };
+
+export default returnObjectSearchingByKey;


### PR DESCRIPTION
Warnings solved:
1. Prefer default export on a file with a single export
1. Unused vars
1. Unexpected require()  Rule ’global-require’
1. Unexpected use of file extension "js" for "./cypress/plugins/index.js"  import/extensions

Evidence

Tests
![image](https://github.com/user-attachments/assets/8eca9c52-8b5b-4368-8635-a09634f9ae58)

SonarQube evidence (pre-peer review)
![image](https://github.com/user-attachments/assets/8f09f45f-eadc-4c38-9023-29128573bf2e)
